### PR TITLE
Remove support for Django 1.8, 1.9, and 1.10

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -7,6 +7,7 @@ Pending release
 .. Insert new release notes below this line
 
 * Drop Python 2 support, only Python 3.4+ is supported now.
+* Drop Django 1.8, 1.9, and 1.10 support. Only Django 1.11+ is supported now.
 
 1.0.0 (2017-04-14)
 ------------------

--- a/README.rst
+++ b/README.rst
@@ -9,7 +9,7 @@ As per `James Pic's idea posted on the django-developers mailing list
 Requirements
 ------------
 
-Python 3.4+ and Django 1.8-2.1 supported.
+Python 3.4+ and Django 1.11-2.1 are supported.
 
 Usage
 -----

--- a/setup.py
+++ b/setup.py
@@ -31,7 +31,7 @@ setup(
     packages=find_packages(exclude=['tests', 'tests.*']),
     include_package_data=True,
     install_requires=[
-        'Django',
+        'Django>=1.11',
     ],
     python_requires='>=3.4',
     license='ISC',
@@ -39,9 +39,6 @@ setup(
     keywords='Django',
     classifiers=[
         'Development Status :: 5 - Production/Stable',
-        'Framework :: Django :: 1.8',
-        'Framework :: Django :: 1.9',
-        'Framework :: Django :: 1.10',
         'Framework :: Django :: 1.11',
         'Framework :: Django :: 2.0',
         'Framework :: Django :: 2.1',

--- a/tox.ini
+++ b/tox.ini
@@ -1,6 +1,6 @@
 [tox]
 envlist =
-    py3-django{18,19,110,111,20,21},
+    py3-django{111,20,21},
     py3-codestyle
 
 [testenv]
@@ -8,9 +8,6 @@ setenv =
     PYTHONDONTWRITEBYTECODE=1
 install_command = pip install --no-deps {opts} {packages}
 deps =
-    django18: Django>=1.8,<1.9
-    django19: Django>=1.9,<1.10
-    django110: Django>=1.10,<1.11
     django111: Django>=1.11,<2.0
     django20: Django>=2.0,<2.1
     django21: Django>=2.1a1,<2.2


### PR DESCRIPTION
* `HISTORY.rst` - add note
* `README.rst` - update list of tested versions
* `setup.py` - specify Django version in `install_requires`, remove classifiers