### PR TITLE
Switch 'pip install' for 'python -m pip install'

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,6 +14,6 @@ matrix:
   - python: 3.8
   - python: 3.9-dev
 
-install: pip install tox-travis
+install: python -m pip install tox-travis
 
 script: tox

--- a/README.rst
+++ b/README.rst
@@ -23,7 +23,7 @@ Python 3.5 to 3.8 and Django 1.11 to 3.0 are supported.
 Usage
 -----
 
-1. Install with ``pip install django-settings-file``.
+1. Install with ``python -m pip install django-settings-file``.
 
 2. Edit your ``manage.py`` and ``wsgi.py`` to swap out Django's default logic for setting ``DJANGO_SETTINGS_MODULE`` to
    instead do:

--- a/tox.ini
+++ b/tox.ini
@@ -8,7 +8,7 @@ envlist =
     py38-codestyle
 
 [testenv]
-install_command = pip install --no-deps {opts} {packages}
+install_command = python -m pip install --no-deps {opts} {packages}
 commands = pytest {posargs}
 
 [testenv:py35-django111]


### PR DESCRIPTION
As per [Brett Cannon's article](https://snarky.ca/why-you-should-use-python-m-pip/).